### PR TITLE
include the protocol while loading imasdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project hosts samples for the [HTML5 IMA SDK](https://developers.google.com
   * Your favorite text editor
   * An HTML5 compliant browser
   * A webserver on which to host the sample
+  * Internet
 
 ### Downloads
 Check out the [releases section](https://github.com/googleads/googleads-ima-html5/releases) for downloadable zips of the source.

--- a/advanced/index.html
+++ b/advanced/index.html
@@ -3,7 +3,9 @@
   <head>
     <link rel="stylesheet" type="text/css" href="style.css"/>
 
-    <script type="text/javascript" src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
+    <script type="text/javascript" src="https://imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
+    <!-- only with https/ http the code works on SmartTV browser 
+    it is safe to say that: All browsers and Bots DO NOT honor RFC 3986 section 4.2. The safest bet is to include the protocol whenever possible -->
     <script type="text/javascript" src="application.js"></script>
     <script type="text/javascript" src="ads.js"></script>
     <script type="text/javascript" src="video_player.js"></script>

--- a/attempt_to_autoplay/index.html
+++ b/attempt_to_autoplay/index.html
@@ -2,7 +2,9 @@
   <head>
     <title>IMA HTML5 Attempt to Autoplay</title>
     <link rel="stylesheet" type="text/css" href="style.css">
-    <script type="text/javascript" src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
+    <script type="text/javascript" src="https://imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
+    <!-- only with https/ http the code works on SmartTV browser 
+    it is safe to say that: All browsers and Bots DO NOT honor RFC 3986 section 4.2. The safest bet is to include the protocol whenever possible -->
     <script type="text/javascript" src="ads.js"></script>
   </head>
 

--- a/live_stream_prefetch/index.html
+++ b/live_stream_prefetch/index.html
@@ -14,7 +14,9 @@
       <div id="adContainer"></div>
     </div>
     <button id="playButton">Play</button>
-    <script type="text/javascript" src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
+    <script type="text/javascript" src="https://imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
+    <!-- only with https/ http the code works on SmartTV browser 
+    it is safe to say that: All browsers and Bots DO NOT honor RFC 3986 section 4.2. The safest bet is to include the protocol whenever possible -->
     <script type="text/javascript" src="ads.js"></script>
   </body>
 </html>

--- a/playlist/index.html
+++ b/playlist/index.html
@@ -3,7 +3,9 @@
   <head>
     <link rel="stylesheet" type="text/css" href="style.css"/>
 
-    <script type="text/javascript" src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
+    <script type="text/javascript" src="https://imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
+    <!-- only with https/ http the code the script works on SmartTV browser (eg: Samsung smart TV 2016)
+    it is safe to say that: All browsers and Bots DO NOT honor RFC 3986 section 4.2. The safest bet is to include the protocol whenever possible -->
     <script type="text/javascript" src="application.js"></script>
     <script type="text/javascript" src="ads.js"></script>
     <script type="text/javascript" src="video_player.js"></script>

--- a/simple/index.html
+++ b/simple/index.html
@@ -14,7 +14,9 @@
       <div id="adContainer"></div>
     </div>
     <button id="playButton">Play</button>
-    <script type="text/javascript" src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
+    <script type="text/javascript" src="https://imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
+     <!-- only with https/ http the code the script works on SmartTV browser (eg: Samsung smart TV 2016)
+    it is safe to say that: All browsers and Bots DO NOT honor RFC 3986 section 4.2. The safest bet is to include the protocol whenever possible -->
     <script type="text/javascript" src="ads.js"></script>
   </body>
 </html>


### PR DESCRIPTION
I was trying out this example on Samsung smart TV application 2018 and 2016 models, the same without protocol while loading sdk did not work and the same started working once I included the protocol.

so it is safe to say that: All browsers and Bots DO NOT honor RFC 3986 section 4.2. The safest bet is to include the protocol whenever possible.

Hope this helps other developers.
Thanks in Advance.
